### PR TITLE
GitHub Actions: require actions to be pinned to full-length commit SHA

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v6
+      uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -22,7 +22,7 @@ jobs:
   test-pgm-version-bump:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set PyPI Version
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Get Latest Release Tag
       id: fetch_tag
-      uses: pozetroninc/github-action-get-latest-release@v0.8.0
+      uses: pozetroninc/github-action-get-latest-release@2a61c339ea7ef0a336d1daa35ef0cb1418e7676c # v0.8.0
       with:
         repository: ${{ github.repository }}
         excludes: prerelease, draft


### PR DESCRIPTION
This is part of our goal to follow security best practices. See also https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#using-third-party-actions

Cfr. https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#controlling-access-to-public-actions-and-reusable-workflows :

> Require actions to be pinned to a full-length commit SHA: All actions must be pinned to a full-length commit SHA to be used. This includes actions from your enterprise and actions authored by GitHub. Reusable workflows can still be referenced by tag. For more information, see [Secure use reference](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#using-third-party-actions).

So we have to pin also the GitHub-owned (`actions/checkout`, ...) and PowerGridModel-owned action (`pgm-version-bump`) before we can enable enforcing.

## Relates to:

* https://github.com/PowerGridModel/power-grid-model/pull/1372
* https://github.com/PowerGridModel/power-grid-model-io/pull/412
* https://github.com/PowerGridModel/power-grid-model-ds/pull/228
* https://github.com/PowerGridModel/pgm-build-dependencies/pull/15
* https://github.com/PowerGridModel/pgm-version-bump/pull/9
* https://github.com/PowerGridModel/power-grid-model-workshop/pull/56
* https://github.com/PowerGridModel/power-grid-model-benchmark/pull/17
* https://github.com/PowerGridModel/homebrew-pgm/pull/1